### PR TITLE
context: make scan take an address to scan

### DIFF
--- a/crazyflie-link/Cargo.toml
+++ b/crazyflie-link/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4"
 rand = "0.8"
 thiserror = "1"
 url = "2.2"
+hex = "0.4.3"
 
 [dev-dependencies]
 anyhow = "1"

--- a/crazyflie-link/examples/scan.rs
+++ b/crazyflie-link/examples/scan.rs
@@ -4,7 +4,7 @@ use crazyflie_link::LinkContext;
 fn main() -> Result<()> {
     let context = crate::LinkContext::new();
 
-    let found = context.scan()?;
+    let found = context.scan([0xe7; 5])?;
 
     println!("Found {} Crazyflies.", found.len());
     for uri in found {

--- a/crazyflie-link/src/context.rs
+++ b/crazyflie-link/src/context.rs
@@ -2,6 +2,7 @@ use crate::error::{Error, Result};
 use crate::Connection;
 use crate::RadioThread;
 use crazyradio::Channel;
+use hex;
 use std::sync::{Arc, Mutex, Weak};
 use url::Url;
 
@@ -30,11 +31,11 @@ impl LinkContext {
         Ok(radio)
     }
 
-    pub fn scan(&self) -> Result<Vec<String>> {
+    pub fn scan(&self, address: [u8; 5]) -> Result<Vec<String>> {
         let channels = self.get_radio(0)?.scan(
             Channel::from_number(0)?,
             Channel::from_number(125)?,
-            [0xe7; 5],
+            address,
             vec![0xff],
         )?;
 
@@ -42,7 +43,8 @@ impl LinkContext {
 
         for channel in channels {
             let channel: u8 = channel.into();
-            found.push(format!("radio://0/{}/2M/E7E7E7E7E7", channel));
+            let address = hex::encode(address.to_vec()).to_uppercase();
+            found.push(format!("radio://0/{}/2M/{}", channel, address));
         }
 
         Ok(found)

--- a/python-binding/src/lib.rs
+++ b/python-binding/src/lib.rs
@@ -15,9 +15,9 @@ impl LinkContext {
         Ok(LinkContext { context })
     }
 
-    fn scan(&self) -> PyResult<Vec<String>> {
+    fn scan(&self, address: [u8; 5]) -> PyResult<Vec<String>> {
         self.context
-            .scan()
+            .scan(address)
             .map_err(|e| PyErr::new::<PyIOError, _>(format!("{:?}", e)))
     }
 


### PR DESCRIPTION
Make scan take an address to scan for

With this the following works for with my Crazyflie:

```
use crazyflie_link::LinkContext;

fn main() {
    let context = crate::LinkContext::new();
    let address = [ 0x00, 0xde, 0xad, 0xbe, 0xef ];

    if let Ok(found) = context.scan(address) {
        println!("Found {} Crazyflies.", found.len());
        for uri in found {
            println!(" - {}", uri)
        }
    }
}
```

```
$ cargo run
Found 1 Crazyflies.
 - radio://0/80/2M/00DEADBEEF
```

